### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/new.sh
+++ b/new.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 pushd .
 cd /tmp
-wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip -O /tmp/GeoIPASNum2.zip
+wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip -O /tmp/GeoIPASNum2.zip
 unzip GeoIPASNum2.zip
 popd
 cat /tmp/GeoIPASNum2.csv |grep -aoP "AS\d+"|grep -aoP "\d+"|sort|uniq > asn.txt


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).